### PR TITLE
Updated scripts

### DIFF
--- a/aligner/provision_species_bwa.sh
+++ b/aligner/provision_species_bwa.sh
@@ -5,7 +5,7 @@ set -e
 export NAME="bwa-species"
 export REGION="asia-northeast1"
 export ZONE="${REGION}-c"
-export MACHINE_TYPE="n1-highmem-4"
+export MACHINE_TYPE="n1-highmem-8"
 export MIN_REPLICAS=1
 export MAX_REPLICAS=3
 export TARGET_CPU_UTILIZATION=0.5

--- a/aligner/provision_species_mm2.sh
+++ b/aligner/provision_species_mm2.sh
@@ -5,7 +5,7 @@ set -e
 export NAME="bwa-species-mm2"
 export REGION="asia-northeast1"
 export ZONE="${REGION}-c"
-export MACHINE_TYPE="n1-highmem-4"
+export MACHINE_TYPE="n1-highmem-8"
 export MIN_REPLICAS=1
 export MAX_REPLICAS=3
 export TARGET_CPU_UTILIZATION=0.5

--- a/dataflow/start_dataflow.sh
+++ b/dataflow/start_dataflow.sh
@@ -31,12 +31,20 @@ KALIGN_ENDPOINT=/cgi-bin/kalign.cgi
 
 # Collections name prefix of the Firestore database that will be used for writing results
 FIRESTORE_COLLECTION_NAME_PREFIX=new_scanning
-# (OPTIONAL) Firestore database document name that will be used for writing statistic results. You can specify it otherwise it will be generated automatically
+
+## OPTIONAL ARGUMENTS
+
+# Firestore database document name that will be used for writing statistic results. You can specify it otherwise it will be generated automatically
 FIRESTORE_STATISTIC_DOCUMENT_NAME=statistic_document
+# Max size of batch that will be generated before alignment. Default value - 2000
+ALIGNMENT_BATCH_SIZE=2000
+# Arguments that will be passed to BWA aligner (worker nodes machine_type). Default value - "-t 4". Can try "-t 8".
+BWA_ARGUMENTS='-t 4'
 
 java -cp /home/coingroupimb/nanostream-dataflow/NanostreamDataflowMain/target/NanostreamDataflowMain-1.0-SNAPSHOT.jar \
   com.google.allenday.nanostream.NanostreamApp \
   --runner=$RUNNER \
+  --region=$ALIGNER_REGION \
   --project=$PROJECT \
   --streaming=true \
   --processingMode=$PROCESSING_MODE \
@@ -45,13 +53,13 @@ java -cp /home/coingroupimb/nanostream-dataflow/NanostreamDataflowMain/target/Na
   --statisticUpdatingDelay=$STATS_UPDATE_FREQUENCY \
   --servicesUrl=$SERVICES_HOST \
   --bwaEndpoint=$BWA_ENDPOINT \
-  --bwaDatabase=$BWA_DATABASE \ 
+  --bwaDatabase=$BWA_DATABASE \
   --kAlignEndpoint=$KALIGN_ENDPOINT \
   --outputFirestoreCollectionNamePrefix=$FIRESTORE_COLLECTION_NAME_PREFIX \
   --outputFirestoreStatisticDocumentName=$FIRESTORE_STATISTIC_DOCUMENT_NAME \
   --resistanceGenesList=$RESISTANCE_GENES_LIST \
   --alignmentBatchSize=$ALIGNMENT_BATCH_SIZE `# (Optional)`\
-  --bwaArguments=$BWA_ARGUMENTS `# (Optional)`
+  --bwaArguments=$BWA_ARGUMENTS `# (Optional)
 
 
 #java -cp /home/coingroupimb/nanostream-dataflow/NanostreamDataflowMain/target/NanostreamDataflowMain-1.0-SNAPSHOT.jar \

--- a/pubsub/make_notifications.sh
+++ b/pubsub/make_notifications.sh
@@ -16,3 +16,9 @@ gcloud pubsub subscriptions create $UPLOAD_SUBSCRIPTION --topic $UPLOAD_EVENTS
 
 #gsutil notification create -t $UPLOAD_EVENTS -f json -e OBJECT_FINALIZE $UPLOAD_BUCKET
 
+##CHECK notification
+#gsutil notification list gs://nano-stream1
+
+##DELETE NOTIFICATION
+#gsutil notification delete <notification name>
+#copy <notification name> from notification list command, looks something like "projects/_/buckets/nano-stream1/notificationConfigs/9"


### PR DESCRIPTION
-added region argument
-changed default species_typing provisioner to `highmem-8`, might still not be enough for the newest >33 GB database, KIV
-added batch size and provisioner node arguments (optional)
-added instructions for checking and deleting object change notifications (commented out)