### PR TITLE
Added more functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,27 @@
 # gcloud
 
-
-
-
-
 Steps
 
-1. Set up firestore as part of gcloud account setup
+1. Log into cloud shell from https://console.cloud.google.com
 
-2. Create storage bucket  called "Uploads"
+2. Set up firestore as part of gcloud account setup
 
-3. Set up UPLOAD_EVENTS topic at https://console.cloud.google.com/cloudpubsub/topicList
+3. Open google cloud shell
 
-4. Log into cloud shell from https://console.cloud.google.com
+4. On cloud shell run `git clone https://github.com/lachlancoin/gcloud.git`
 
-5. On cloud shell run  git clone https://github.com/lachlancoin/gcloud.git
+5. On cloud shell run `bash ./gcloud/init.sh bwa_species`
 
-6. On cloud she run  bash ./gcloud/init.sh bwa_species
+6. From local computer run `bash ./gcloud/realtime/rt-sync.sh  local_path_to_fastq Uploads`
 
-7. From local computer Run:  bash ./gcloud/realtime/rt-sync.sh  local_path_to_fastq Uploads
+7. Results can be seen on https://{PROJECT}.appspot.com (for example, https://nano-stream1.appspot.com)
 
-8. When finished run bash ./gcloud/shutdown.sh (from cloud shell)
+8. When finished, on cloud shell run `bash ./gcloud/shutdown.sh`
 
+Results 
 
+ 
 
+Following steps have been automated, I've archived them below in case errors are found in the future and they need to be done through the GUI.
+2.1 Create storage bucket called "Uploads" atomated in init.sh
+2.2 Set up UPLOAD_EVENTS topic at https://console.cloud.google.com/cloudpubsub/topicList

--- a/README.md
+++ b/README.md
@@ -18,10 +18,6 @@ Steps
 
 8. When finished, on cloud shell run `bash ./gcloud/shutdown.sh`
 
-Results 
-
- 
-
 Following steps have been automated, I've archived them below in case errors are found in the future and they need to be done through the GUI.
 2.1 Create storage bucket called "Uploads" atomated in init.sh
 2.2 Set up UPLOAD_EVENTS topic at https://console.cloud.google.com/cloudpubsub/topicList

--- a/TODO holidays
+++ b/TODO holidays
@@ -1,0 +1,13 @@
+TODO:
+
+Automate PubSub TOPIC
+  check done
+  create done
+
+Automate VISUALISER
+  Write variables in various .html and .yaml files
+  launch app engine
+
+Automate MONITOR
+  Write variables in various .html and .yaml files
+  launch app engine

--- a/TODO holidays
+++ b/TODO holidays
@@ -5,9 +5,9 @@ Automate PubSub TOPIC
   create done
 
 Automate VISUALISER
-  Write variables in various .html and .yaml files
-  launch app engine
+  Write variables in various .html and .yaml files uh oh can't be done, maybe a new file for users to copy paste into?
+  launch app engine done
 
 Automate MONITOR
-  Write variables in various .html and .yaml files
-  launch app engine
+  Write variables in various .html and .yaml files done
+  launch app engine done

--- a/TODO holidays
+++ b/TODO holidays
@@ -1,13 +1,15 @@
 TODO:
 
 Automate PubSub TOPIC
-  check done
-  create done
+  check #done
+  create #done
 
 Automate VISUALISER
-  Write variables in various .html and .yaml files uh oh can't be done, maybe a new file for users to copy paste into?
-  launch app engine done
+  Write variables in various .html and .yaml files uh oh can't be done, maybe a new file for users to copy paste into? #done
+  launch app engine #done
 
 Automate MONITOR
-  Write variables in various .html and .yaml files done
-  launch app engine done
+  Write variables in various .html and .yaml files #done
+  launch app engine #done
+  
+Also replaced references to Allen Day's nanostream github to Larry's for the above to work. References to Allen Day's bwamem docker stuff have been left intact.

--- a/ignore
+++ b/ignore
@@ -1,0 +1,1 @@
+This file can be ignored, only function is as a workaround in creating bucket subfolders from gsutil.

--- a/init.sh
+++ b/init.sh
@@ -314,9 +314,11 @@ fi
 sed -i "s/original/new/g" file.txt
 
 
-## Check out the source for nanostream-dataflow TODO change this to Larry's for localisable variables?
+## Check out the source for nanostream-dataflow. 
+## Originally downloaded Allen Day's nanostream-dataflow git, but updated to Larry's to automate the website stuff below.
+## If this doesn't work out, can be returned to original by replacing "Firedrops" with "allenday" 2 lines down.
 if [ ! -e "./nanostream-dataflow" ]; then
-	git clone "https://github.com/allenday/nanostream-dataflow.git"
+	git clone "https://github.com/Firedrops/nanostream-dataflow.git"
 else
 	cd ./nanostream-dataflow/
 	uptodate=$(git pull | grep 'up-to-date' | wc -l) ## get latest version

--- a/init.sh
+++ b/init.sh
@@ -30,8 +30,8 @@ export RESISTANCE_GENES_LIST=gs://$DATABASES/$RESISTANCE_DB/geneList
 export ALIGNER_REGION="asia-northeast1"
 export UPLOAD_BUCKET="Uploads";
 export UPLOAD_EVENTS="UPLOAD_EVENTS"
-export VISUALISER="visualiser_website"
-export MONITOR="monitoring_website"
+export VISUALISER="visualiser-site"
+export MONITOR="monitor-site"
 export REGION=$ALIGNER_REGION
 export ZONE="${REGION}-c"
 export RESULTS_PREFIX="${RESNAME}_${currdate}"
@@ -39,6 +39,7 @@ export MIN_REPLICAS=1
 export MAX_REPLICAS=3
 export TARGET_CPU_UTILIZATION=0.5
 
+export VERIFICATION="coingroupimb"
 
 
 
@@ -200,7 +201,7 @@ else
 	fi
 fi
 
-## TODO WEBSITE STUFF HERE 
+## TODO WEBSITE STUFF HERE
 
 ## Check out the source for nanostream-dataflow
 if [ ! -e "./nanostream-dataflow" ]; then


### PR DESCRIPTION
Haven't been tested yet, but if it goes well, it should also automate:
  Both websites (monitoring and results)
  Bucket creation
  All PubSub topics/subscriptions

Things to double check:
  formatting of $PROJECT or ${PROJECT}?
  shutdown.sh doesn't appear to turn off the websites, intentional?

Things that can't seem to be automated (currently, anyway)
  Creation of Firestore and
  Copying of Firestore variables to the results website's .html. 
These won't affect us personally since they've been manually copied, but remind other parties to update their "var config" in sunburst.html if they're using the script elsewhere! Otherwise it won't work or they'll get our results instead.